### PR TITLE
Control Client, Change up-party default interval for reading external…

### DIFF
--- a/src/FoxIDs.Control/FoxIDs.Control.csproj
+++ b/src/FoxIDs.Control/FoxIDs.Control.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<TargetFramework>net6.0</TargetFramework>
-		<Version>1.0.6.6</Version>
+		<Version>1.0.6.7</Version>
 		<RootNamespace>FoxIDs</RootNamespace>
 		<Authors>Anders Revsgaard</Authors>
 		<Company>ITfoxtec</Company>

--- a/src/FoxIDs.ControlClient/FoxIDs.ControlClient.csproj
+++ b/src/FoxIDs.ControlClient/FoxIDs.ControlClient.csproj
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<TargetFramework>net6.0</TargetFramework>
 		<RazorLangVersion>3.0</RazorLangVersion>
-		<Version>1.0.6.6</Version>
+		<Version>1.0.6.7</Version>
 		<RootNamespace>FoxIDs.Client</RootNamespace>
 		<Authors>Anders Revsgaard</Authors>
 		<Company>ITfoxtec</Company>

--- a/src/FoxIDs.ControlClient/Models/ViewModels/Parties/OidcUpPartyViewModel.cs
+++ b/src/FoxIDs.ControlClient/Models/ViewModels/Parties/OidcUpPartyViewModel.cs
@@ -19,8 +19,8 @@ namespace FoxIDs.Client.Models.ViewModels
         public bool AutomaticStopped { get; set; }
 
         [Range(Constants.Models.OAuthUpParty.OidcDiscoveryUpdateRateMin, Constants.Models.OAuthUpParty.OidcDiscoveryUpdateRateMax)]
-        [Display(Name = "Automatic update rate")]
-        public int OidcDiscoveryUpdateRate { get; set; } = 2592000; // 30 days
+        [Display(Name = "Automatic update rate in seconds")]
+        public int OidcDiscoveryUpdateRate { get; set; } = 172800; // 2 days
 
         [Required]
         [MaxLength(Constants.Models.OAuthUpParty.AuthorityLength)]

--- a/src/FoxIDs.ControlClient/Models/ViewModels/Parties/SamlUpPartyViewModel.cs
+++ b/src/FoxIDs.ControlClient/Models/ViewModels/Parties/SamlUpPartyViewModel.cs
@@ -22,8 +22,8 @@ namespace FoxIDs.Client.Models.ViewModels
         public bool AutomaticStopped { get; set; }
 
         [Range(Constants.Models.SamlParty.MetadataUpdateRateMin, Constants.Models.SamlParty.MetadataUpdateRateMax)]
-        [Display(Name = "Automatic update rate")]
-        public int MetadataUpdateRate { get; set; } = 2592000; // 30 days
+        [Display(Name = "Automatic update rate in seconds")]
+        public int MetadataUpdateRate { get; set; } = 172800; // 2 days
 
         [MaxLength(Constants.Models.SamlParty.MetadataUrlLength)]
         [Display(Name = "Metadata URL")]

--- a/src/FoxIDs.ControlShared/FoxIDs.ControlShared.csproj
+++ b/src/FoxIDs.ControlShared/FoxIDs.ControlShared.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<TargetFramework>net6.0</TargetFramework>
-		<Version>1.0.6.6</Version>
+		<Version>1.0.6.7</Version>
 		<RootNamespace>FoxIDs</RootNamespace>
 		<Authors>Anders Revsgaard</Authors>
 		<Company>ITfoxtec</Company>

--- a/src/FoxIDs.Shared/FoxIDs.Shared.csproj
+++ b/src/FoxIDs.Shared/FoxIDs.Shared.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<TargetFramework>net6.0</TargetFramework>
-		<Version>1.0.6.6</Version>
+		<Version>1.0.6.7</Version>
 		<RootNamespace>FoxIDs</RootNamespace>
 		<Authors>Anders Revsgaard</Authors>
 		<Company>ITfoxtec</Company>

--- a/src/FoxIDs.SharedBase/Constants.cs
+++ b/src/FoxIDs.SharedBase/Constants.cs
@@ -356,8 +356,8 @@ namespace FoxIDs
                 public const int KeysApiMin = 0;
                 public const int KeysMin = 1;
                 public const int KeysMax = 10;
-                public const int OidcDiscoveryUpdateRateMin = 86400; // 24 hours
-                public const int OidcDiscoveryUpdateRateMax = 31536000; // 12 month
+                public const int OidcDiscoveryUpdateRateMin = 14400; // 4 hours
+                public const int OidcDiscoveryUpdateRateMax = 5184000; // 60 days
 
                 public const int ScopeLength = 50;
                 public const string ScopeRegExPattern = @"^[\w:\-/.]*$";
@@ -394,8 +394,8 @@ namespace FoxIDs
             {
                 public const int MetadataUrlLength = 500;
                 public const int MetadataXmlSize = 200000; // 200kB
-                public const int MetadataUpdateRateMin = 86400; // 24 hours
-                public const int MetadataUpdateRateMax = 31536000; // 12 month
+                public const int MetadataUpdateRateMin = 14400; // 4 hours
+                public const int MetadataUpdateRateMax = 5184000; // 60 days
                 public const int MetadataNameIdFormatsMin = 0;
                 public const int MetadataNameIdFormatsMax = 5;
                 public const int MetadataContactPersonsMin = 0;

--- a/src/FoxIDs.SharedBase/FoxIDs.SharedBase.csproj
+++ b/src/FoxIDs.SharedBase/FoxIDs.SharedBase.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<TargetFramework>net6.0</TargetFramework>
-		<Version>1.0.6.6</Version>
+		<Version>1.0.6.7</Version>
 		<RootNamespace>FoxIDs</RootNamespace>
 		<Authors>Anders Revsgaard</Authors>
 		<Company>ITfoxtec</Company>

--- a/src/FoxIDs/FoxIDs.csproj
+++ b/src/FoxIDs/FoxIDs.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 	<PropertyGroup>
 		<TargetFramework>net6.0</TargetFramework>
-		<Version>1.0.6.6</Version>
+		<Version>1.0.6.7</Version>
 		<RootNamespace>FoxIDs</RootNamespace>
 		<Authors>Anders Revsgaard</Authors>
 		<Company>ITfoxtec</Company>


### PR DESCRIPTION
… OIDC discovery and SAML metadata to 172800; // 2 days.

Change max and min values in data model.