### PR TITLE
Fix cross platform issues

### DIFF
--- a/src/FoxIDs.Control/Infrastructure/Hosting/ServiceCollectionExtensions.cs
+++ b/src/FoxIDs.Control/Infrastructure/Hosting/ServiceCollectionExtensions.cs
@@ -85,7 +85,7 @@ namespace FoxIDs.Infrastructure.Hosting
 
         public static IServiceCollection AddInfrastructure(this IServiceCollection services, FoxIDsControlSettings settings, IWebHostEnvironment env)
         {
-            services.AddSharedInfrastructure(settings);
+            services.AddSharedInfrastructure(settings, env);
 
             services.AddScoped<FoxIDsApiRouteTransformer>();
 

--- a/src/FoxIDs.Control/Properties/launchSettings.json
+++ b/src/FoxIDs.Control/Properties/launchSettings.json
@@ -8,6 +8,14 @@
     }
   },
   "profiles": {
+    "Default": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "applicationUrl": "https://localhost:44331",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
     "IIS Express": {
       "commandName": "IISExpress",
       "launchBrowser": true,

--- a/src/FoxIDs.Control/appsettings.Development.json
+++ b/src/FoxIDs.Control/appsettings.Development.json
@@ -1,7 +1,7 @@
 {
   "Settings": {
-    "FoxIDsEndpoint": "http://localhost:44330",
-    "FoxIDsControlEndpoint": "http://localhost:44331",
+    "FoxIDsEndpoint": "https://localhost:44330",
+    "FoxIDsControlEndpoint": "https://localhost:44331",
     "Options": {
       "Log": "None",
       "DataStorage": "File",

--- a/src/FoxIDs.Control/appsettings.Development.json
+++ b/src/FoxIDs.Control/appsettings.Development.json
@@ -1,0 +1,13 @@
+{
+  "Settings": {
+    "FoxIDsEndpoint": "http://localhost:44330",
+    "FoxIDsControlEndpoint": "http://localhost:44331",
+    "Options": {
+      "Log": "None",
+      "DataStorage": "File",
+      "KeyStorage": "None",
+      "Cache": "File",
+      "DataCache": "None"
+    }
+  }
+}

--- a/src/FoxIDs.Shared/Logic/Master/EmbeddedResourceLogic.cs
+++ b/src/FoxIDs.Shared/Logic/Master/EmbeddedResourceLogic.cs
@@ -58,6 +58,6 @@ namespace FoxIDs.Logic
 
         private string EmbeddedResourceName => $"{typeof(EmbeddedResource).FullName}.json";
 
-        private string EmbeddedResourceFile => EmbeddedResourceName.Replace('.', Path.PathSeparator).Replace($@"{Path.PathSeparator}json", ".json").Replace($@"FoxIDs{Path.PathSeparator}", $@"..{Path.PathSeparator}FoxIDs.Shared{Path.PathSeparator}");
+        private string EmbeddedResourceFile => EmbeddedResourceName.Replace('.', '\\').Replace(@"\json", ".json").Replace(@"FoxIDs\", @"..\FoxIDs.Shared\");
     }
 }

--- a/src/FoxIDs.Shared/Logic/Master/EmbeddedResourceLogic.cs
+++ b/src/FoxIDs.Shared/Logic/Master/EmbeddedResourceLogic.cs
@@ -58,6 +58,6 @@ namespace FoxIDs.Logic
 
         private string EmbeddedResourceName => $"{typeof(EmbeddedResource).FullName}.json";
 
-        private string EmbeddedResourceFile => EmbeddedResourceName.Replace('.', '\\').Replace(@"\json", ".json").Replace(@"FoxIDs\", @"..\FoxIDs.Shared\");
+        private string EmbeddedResourceFile => EmbeddedResourceName.Replace('.', Path.PathSeparator).Replace($@"{Path.PathSeparator}json", ".json").Replace($@"FoxIDs{Path.PathSeparator}", $@"..{Path.PathSeparator}FoxIDs.Shared{Path.PathSeparator}");
     }
 }

--- a/src/FoxIDs.Shared/Logic/Master/EmbeddedResourceLogic.cs
+++ b/src/FoxIDs.Shared/Logic/Master/EmbeddedResourceLogic.cs
@@ -58,6 +58,6 @@ namespace FoxIDs.Logic
 
         private string EmbeddedResourceName => $"{typeof(EmbeddedResource).FullName}.json";
 
-        private string EmbeddedResourceFile => EmbeddedResourceName.Replace('.', '\\').Replace(@"\json", ".json").Replace(@"FoxIDs\", @"..\FoxIDs.Shared\");
+        private string EmbeddedResourceFile => EmbeddedResourceName.Replace('.', Path.PathSeparator).Replace($"{Path.PathSeparator}json", ".json").Replace($"FoxIDs{Path.PathSeparator}", $"..{Path.PathSeparator}FoxIDs.Shared{Path.PathSeparator}");
     }
 }

--- a/src/FoxIDs.Shared/Logic/Parties/OidcDiscoveryReadLogic.cs
+++ b/src/FoxIDs.Shared/Logic/Parties/OidcDiscoveryReadLogic.cs
@@ -96,7 +96,7 @@ namespace FoxIDs.Logic
 
         protected async Task<OidcDiscovery> GetOidcDiscoveryAsync(string oidcDiscoveryUrl)
         {
-            var httpClient = httpClientFactory.CreateClient(nameof(HttpClient));
+            var httpClient = httpClientFactory.CreateClient();
             using var response = await httpClient.SendAsync(new HttpRequestMessage(HttpMethod.Get, oidcDiscoveryUrl));
             // Handle the response
             switch (response.StatusCode)
@@ -113,7 +113,7 @@ namespace FoxIDs.Logic
 
         protected async Task<JsonWebKeySet> GetOidcDiscoveryKeysAsync(string jwksUri)
         {
-            var httpClient = httpClientFactory.CreateClient(nameof(HttpClient));
+            var httpClient = httpClientFactory.CreateClient();
             using var response = await httpClient.SendAsync(new HttpRequestMessage(HttpMethod.Get, jwksUri));
             // Handle the response
             switch (response.StatusCode)

--- a/src/FoxIDs.Shared/Logic/Parties/SamlMetadataReadLogic.cs
+++ b/src/FoxIDs.Shared/Logic/Parties/SamlMetadataReadLogic.cs
@@ -28,7 +28,7 @@ namespace FoxIDs.Logic
 
         private async Task<string> ReadMetadataAsync(string metadataUrl)
         {
-            var httpClient = httpClientFactory.CreateClient(nameof(HttpClient));
+            var httpClient = httpClientFactory.CreateClient();
             using var response = await httpClient.SendAsync(new HttpRequestMessage(HttpMethod.Get, metadataUrl));
             // Handle the response
             switch (response.StatusCode)

--- a/src/FoxIDs.Shared/Models/Config/FileDataSettings.cs
+++ b/src/FoxIDs.Shared/Models/Config/FileDataSettings.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel.DataAnnotations;
+using System.IO;
 
 namespace FoxIDs.Models.Config
 {
@@ -8,7 +9,7 @@ namespace FoxIDs.Models.Config
         /// Save data in directory if the DataStore option is File.
         /// </summary>
         [Required]
-        public string DataPath { get; set; } = "..\\..\\";
+        public string DataPath { get; set; } = Path.Join("..", "..");
 
         /// <summary>
         /// The background file data service wait period in seconds.

--- a/src/FoxIDs.Shared/Repository/Files/FileDataRepository.cs
+++ b/src/FoxIDs.Shared/Repository/Files/FileDataRepository.cs
@@ -297,7 +297,7 @@ namespace FoxIDs.Repository
 
         private string GetFilePartitionId(string partitionId) => partitionId.Replace(':', '_');
 
-        private string GetDataPath() => Path.Join($"{settings.FileData.DataPath.TrimEnd('\\').TrimEnd('/')}", "data");
+        private string GetDataPath() => Path.Join(settings.FileData.DataPath, "data");
         private string GetDbPath() => Path.Join(GetDataPath(), "db");
         private string GetCachePath() => Path.Join(GetDataPath(), Constants.Models.DataType.Cache);
     }

--- a/src/FoxIDs.Shared/Repository/Files/FileDataRepository.cs
+++ b/src/FoxIDs.Shared/Repository/Files/FileDataRepository.cs
@@ -49,7 +49,7 @@ namespace FoxIDs.Repository
             var filePaths = Directory.GetFiles(GetDbPath());
             foreach (string filePath in filePaths)
             {
-                var filePathSplit = filePath.Split('\\');
+                var filePathSplit = filePath.Split(Path.PathSeparator);
                 if (partitionId.IsNullOrWhiteSpace())
                 {
                     filePathSplit = filePathSplit[filePathSplit.Length - 1].Split('|');
@@ -117,7 +117,7 @@ namespace FoxIDs.Repository
             var selectedFilePaths = new List<string>();
             foreach (string filePath in filePaths)
             {
-                var filePathSplit = filePath.Split('\\');
+                var filePathSplit = filePath.Split(Path.PathSeparator);
                 if (partitionId.IsNullOrWhiteSpace())
                 {
                     filePathSplit = filePathSplit[filePathSplit.Length - 1].Split('|');
@@ -207,7 +207,7 @@ namespace FoxIDs.Repository
             var count = 0;
             foreach (string filePath in Directory.GetFiles(GetDbPath()))
             {
-                var filePathSplit = filePath.Split('\\');
+                var filePathSplit = filePath.Split(Path.PathSeparator);
                 if (filePathSplit[filePathSplit.Length - 1].StartsWith(GetFilePartitionIdAndDataType(partitionId, dataType), StringComparison.Ordinal))
                 {
                     File.Delete(filePath);
@@ -263,7 +263,7 @@ namespace FoxIDs.Repository
         private async Task<string> GetFilePathAsync(string id, string partitionId)
         {
             var idSplit = id.Split(':');
-            return $"{GetPath(idSplit)}\\{GetFilePartitionId(partitionId)}^{GetPre(id, idSplit)}{await id.HashIdStringAsync()}.data";
+            return $"{GetPath(idSplit)}{Path.PathSeparator}{GetFilePartitionId(partitionId)}^{GetPre(id, idSplit)}{await id.HashIdStringAsync()}.data";
         }
 
         private string GetPre(string id, string[] idSplit)
@@ -297,8 +297,8 @@ namespace FoxIDs.Repository
 
         private string GetFilePartitionId(string partitionId) => partitionId.Replace(':', '_');
 
-        private string GetDataPath() => $"{settings.FileData.DataPath.TrimEnd('\\')}\\data";
-        private string GetDbPath() => $"{GetDataPath()}\\db";
-        private string GetCachePath() => $"{GetDataPath()}\\{Constants.Models.DataType.Cache}";
+        private string GetDataPath() => Path.Join($"{settings.FileData.DataPath.TrimEnd('\\').TrimEnd('/')}", "data");
+        private string GetDbPath() => Path.Join(GetDataPath(), "db");
+        private string GetCachePath() => Path.Join(GetDataPath(), Constants.Models.DataType.Cache);
     }
 }

--- a/src/FoxIDs/Infrastructure/Hosting/ServiceCollectionExtensions.cs
+++ b/src/FoxIDs/Infrastructure/Hosting/ServiceCollectionExtensions.cs
@@ -123,7 +123,7 @@ namespace FoxIDs.Infrastructure.Hosting
 
         public static IServiceCollection AddInfrastructure(this IServiceCollection services, FoxIDsSettings settings, IWebHostEnvironment env)
         {
-            services.AddSharedInfrastructure(settings);
+            services.AddSharedInfrastructure(settings, env);
 
             services.AddSingleton<IStringLocalizer, FoxIDsStringLocalizer>();
             services.AddSingleton<IStringLocalizerFactory, FoxIDsStringLocalizerFactory>();

--- a/src/FoxIDs/Logic/OAuth/OAuthAuthUpLogic.cs
+++ b/src/FoxIDs/Logic/OAuth/OAuthAuthUpLogic.cs
@@ -117,7 +117,7 @@ namespace FoxIDs.Logic
             ValidateClientUserInfoSupport(client);
             logger.ScopeTrace(() => $"AuthMethod, OIDC UserInfo request URL '{client.UserInfoUrl}'.", traceType: TraceTypes.Message);
 
-            var httpClient = httpClientFactory.CreateClient(nameof(HttpClient));
+            var httpClient = httpClientFactory.CreateClient();
             httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(IdentityConstants.TokenTypes.Bearer, accessToken);
 
             using var response = await httpClient.GetAsync(client.UserInfoUrl);

--- a/src/FoxIDs/Logic/Oidc/OidcAuthUpLogic.cs
+++ b/src/FoxIDs/Logic/Oidc/OidcAuthUpLogic.cs
@@ -421,7 +421,7 @@ namespace FoxIDs.Logic
 
             request.Content = new FormUrlEncodedContent(requestDictionary);
 
-            using var response = await httpClientFactory.CreateClient(nameof(HttpClient)).SendAsync(request);
+            using var response = await httpClientFactory.CreateClient().SendAsync(request);
             switch (response.StatusCode)
             {
                 case HttpStatusCode.OK:

--- a/src/FoxIDs/Properties/launchSettings.json
+++ b/src/FoxIDs/Properties/launchSettings.json
@@ -8,6 +8,14 @@
     }
   },
   "profiles": {
+    "Default": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "applicationUrl": "https://localhost:44330",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
     "IIS Express": {
       "commandName": "IISExpress",
       "environmentVariables": {

--- a/src/FoxIDs/appsettings.Development.json
+++ b/src/FoxIDs/appsettings.Development.json
@@ -1,6 +1,6 @@
 {
   "Settings": {
-    "FoxIDsEndpoint": "http://localhost:44330",
+    "FoxIDsEndpoint": "https://localhost:44330",
     "Options": {
       "Log": "None",
       "DataStorage": "File",

--- a/src/FoxIDs/appsettings.Development.json
+++ b/src/FoxIDs/appsettings.Development.json
@@ -1,0 +1,12 @@
+{
+  "Settings": {
+    "FoxIDsEndpoint": "http://localhost:44330",
+    "Options": {
+      "Log": "None",
+      "DataStorage": "File",
+      "KeyStorage": "None",
+      "Cache": "File",
+      "DataCache": "None"
+    }
+  }
+}


### PR DESCRIPTION
There are some path separator issues causing the code to fail on Linux and I think it makes sense to keep the dev appsettings in repo. With this PR I can start FoxIDs and Control with `dotnet run` in respective project folder.