### PR TITLE
Update PgKeyValueDB

### DIFF
--- a/src/FoxIDs.Shared/FoxIDs.Shared.csproj
+++ b/src/FoxIDs.Shared/FoxIDs.Shared.csproj
@@ -30,7 +30,7 @@
 		<PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.6.0" />
 		<PackageReference Include="Azure.Security.KeyVault.Certificates" Version="4.6.0" />
 		<PackageReference Include="MongoDB.Driver" Version="2.24.0" />
-		<PackageReference Include="PgKeyValueDB" Version="0.4.1" />
+		<PackageReference Include="PgKeyValueDB" Version="0.4.2" />
 		<PackageReference Include="RSAKeyVaultProvider" Version="2.1.1" />
 		<PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="8.0.4" />
 		<PackageReference Include="SendGrid" Version="9.29.3" />


### PR DESCRIPTION
Bugfix for bad index naming causing them to not be created when multiple instances to the same db is used.