### PR TITLE
Update ITfoxtec.Identity.Saml2 to version 4.11.3.

### DIFF
--- a/src/FoxIDs.Control/FoxIDs.Control.csproj
+++ b/src/FoxIDs.Control/FoxIDs.Control.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<TargetFramework>net8.0</TargetFramework>
-		<Version>1.5.0</Version>
+		<Version>1.5.1</Version>
 		<RootNamespace>FoxIDs</RootNamespace>
 		<Authors>Anders Revsgaard</Authors>
 		<Company>ITfoxtec</Company>

--- a/src/FoxIDs.ControlClient/FoxIDs.ControlClient.csproj
+++ b/src/FoxIDs.ControlClient/FoxIDs.ControlClient.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<TargetFramework>net8.0</TargetFramework>
-		<Version>1.5.0</Version>
+		<Version>1.5.1</Version>
 		<RootNamespace>FoxIDs.Client</RootNamespace>
 		<Authors>Anders Revsgaard</Authors>
 		<Company>ITfoxtec</Company>

--- a/src/FoxIDs.ControlShared/FoxIDs.ControlShared.csproj
+++ b/src/FoxIDs.ControlShared/FoxIDs.ControlShared.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<TargetFramework>net8.0</TargetFramework>
-		<Version>1.5.0</Version>
+		<Version>1.5.1</Version>
 		<RootNamespace>FoxIDs</RootNamespace>
 		<Authors>Anders Revsgaard</Authors>
 		<Company>ITfoxtec</Company>

--- a/src/FoxIDs.Shared/FoxIDs.Shared.csproj
+++ b/src/FoxIDs.Shared/FoxIDs.Shared.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<TargetFramework>net8.0</TargetFramework>
-		<Version>1.5.0</Version>
+		<Version>1.5.1</Version>
 		<RootNamespace>FoxIDs</RootNamespace>
 		<Authors>Anders Revsgaard</Authors>
 		<Company>ITfoxtec</Company>

--- a/src/FoxIDs.SharedBase/FoxIDs.SharedBase.csproj
+++ b/src/FoxIDs.SharedBase/FoxIDs.SharedBase.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<TargetFramework>net8.0</TargetFramework>
-		<Version>1.5.0</Version>
+		<Version>1.5.1</Version>
 		<RootNamespace>FoxIDs</RootNamespace>
 		<Authors>Anders Revsgaard</Authors>
 		<Company>ITfoxtec</Company>
@@ -10,8 +10,8 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="ITfoxtec.Identity" Version="2.6.0" />
-		<PackageReference Include="ITfoxtec.Identity.Saml2" Version="4.11.1" />
+		<PackageReference Include="ITfoxtec.Identity" Version="2.7.0" />
+		<PackageReference Include="ITfoxtec.Identity.Saml2" Version="4.11.3" />
 		<PackageReference Include="Microsoft.AspNetCore.Components.DataAnnotations.Validation" Version="3.2.0-rc1.20223.4" />
 		<PackageReference Include="System.Net.Http.Json" Version="8.0.0" />
 	</ItemGroup>

--- a/src/FoxIDs/FoxIDs.csproj
+++ b/src/FoxIDs/FoxIDs.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 	<PropertyGroup>
 		<TargetFramework>net8.0</TargetFramework>
-		<Version>1.5.0</Version>
+		<Version>1.5.1</Version>
 		<RootNamespace>FoxIDs</RootNamespace>
 		<Authors>Anders Revsgaard</Authors>
 		<Company>ITfoxtec</Company>
@@ -31,7 +31,7 @@
 		<PackageReference Include="Azure.Identity" Version="1.11.3" />
 		<PackageReference Include="Azure.Security.KeyVault.Certificates" Version="4.6.0" />
 		<PackageReference Include="GoogleAuthenticator" Version="3.2.0" />
-		<PackageReference Include="ITfoxtec.Identity.Saml2.MvcCore" Version="4.11.0" />
+		<PackageReference Include="ITfoxtec.Identity.Saml2.MvcCore" Version="4.11.3" />
 		<PackageReference Include="BuildBundlerMinifier" Version="3.2.449" />
 		<PackageReference Include="Microsoft.AspNetCore.DataProtection.StackExchangeRedis" Version="8.0.5" />
 		<PackageReference Include="Microsoft.AspNetCore.Cryptography.KeyDerivation" Version="8.0.5" />


### PR DESCRIPTION
Remove local repeated namespace from Scoping, IDPList and IDPEntry. Resolve Scoping.RequesterID and IDPList.GetComplete issued as an attribute instead of an element bug. Resolve scoping bug "Unable to convert element ITfoxtec.Identity.Saml2.Schemas.Scoping".