### PR TITLE
Extend Claims.ValuesMax = 250 to meet Azure max values

### DIFF
--- a/src/FoxIDs.SharedBase/Constants.cs
+++ b/src/FoxIDs.SharedBase/Constants.cs
@@ -437,7 +437,7 @@ namespace FoxIDs
 
                 public const int ValuesOAuthMin = 0;
                 public const int ValuesUserMin = 1;
-                public const int ValuesMax = 100;
+                public const int ValuesMax = 250;
 
                 /// <summary>
                 /// JWT and SAML claim value max length.


### PR DESCRIPTION
Extend Claims.ValuesMax = 250 to meet Azure max values (200 groups for JSON web tokens - https://learn.microsoft.com/en-us/security/zero-trust/develop/configure-tokens-group-claims-app-roles#group-overages)

The reason of this changes is the error I got for one particular user:

`FoxIDs.Infrastructure.DataAnnotations.ValidationResultException: AuthCodeTtlGrant: [Claims.Values: The field Values must be between 1 and 100.]`

Detailed investigation showed that user has around 150 groups and this could be the reason of failed login.
While groups are sent in access_token, as Anders suggests, I suppose it's quite safe to extend the max value to be +- on the same level of claims amount as Azure AD